### PR TITLE
feat: add active filter indicators and reset control closes #23

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -266,6 +266,12 @@ useEffect(() => {
   }
 }, [tasks, keystoneTaskId, momentumRunActive]);
 
+function handleResetFilters() {
+  setFilterLoad("all");
+  setFilterPriority("all");
+  setFilterContext("all");
+}
+
 // Set keystone task
 function handleSetKeystone(taskId) {
   setKeystoneTaskId(taskId);
@@ -622,6 +628,7 @@ if (!settingsLoaded) {
           contextOptions={contextOptions}
           loadLabels={LOAD_LABELS}
           priorityLabels={PRIORITY_LABELS}
+          onResetFilters={handleResetFilters}
         />
       </section>
 

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -10,38 +10,70 @@ function FilterBar({
   contextOptions,
   loadLabels,
   priorityLabels,
+  onResetFilters,
 }) {
+  const hasActiveFilters =
+    filterLoad !== "all" ||
+    filterPriority !== "all" ||
+    filterContext !== "all";
+
+  const filterSelectClass = "filter-select";
+
   return (
-    <div className="filter-bar">
-      <select value={filterLoad} onChange={(e) => setFilterLoad(e.target.value)}>
-        <option value="all">All cognitive loads</option>
-        {Object.entries(loadLabels).map(([value, label]) => (
-          <option key={value} value={value}>
-            {label}
-          </option>
-        ))}
-      </select>
+    <div className="filter-bar-wrapper">
+      <div className="filter-bar">
+        <div className={filterLoad !== "all" ? "filter-select-wrap filter-select-wrap--active" : "filter-select-wrap"}>
+          <select
+            className={filterSelectClass}
+            value={filterLoad}
+            onChange={(e) => setFilterLoad(e.target.value)}
+          >
+            <option value="all">All cognitive loads</option>
+            {Object.entries(loadLabels).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
 
-      <select
-        value={filterPriority}
-        onChange={(e) => setFilterPriority(e.target.value)}
-      >
-        <option value="all">All priorities</option>
-        {Object.entries(priorityLabels).map(([value, label]) => (
-          <option key={value} value={value}>
-            {label}
-          </option>
-        ))}
-      </select>
+        <div className={filterPriority !== "all" ? "filter-select-wrap filter-select-wrap--active" : "filter-select-wrap"}>
+          <select
+            className={filterSelectClass}
+            value={filterPriority}
+            onChange={(e) => setFilterPriority(e.target.value)}
+          >
+            <option value="all">All priorities</option>
+            {Object.entries(priorityLabels).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
 
-      <select value={filterContext} onChange={(e) => setFilterContext(e.target.value)}>
-        <option value="all">All contexts</option>
-        {contextOptions.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
+        <div className={filterContext !== "all" ? "filter-select-wrap filter-select-wrap--active" : "filter-select-wrap"}>
+          <select
+            className={filterSelectClass}
+            value={filterContext}
+            onChange={(e) => setFilterContext(e.target.value)}
+          >
+            <option value="all">All contexts</option>
+            {contextOptions.map((option) => (
+              <option key={option} value={option}>{option}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {hasActiveFilters && (
+        <div className="filter-bar__status">
+          <span className="filter-bar__active-label">Filters active</span>
+          <button
+            type="button"
+            className="filter-bar__reset"
+            onClick={onResetFilters}
+          >
+            Reset filters
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/styles/filter-bar.css
+++ b/src/styles/filter-bar.css
@@ -1,17 +1,95 @@
-@media (max-width: 640px) {
-
-  .filter-bar {
-    flex-direction: column;
-  }
-
-  .filter-bar select {
-    width: 100%;
-  }
+.filter-bar-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .filter-bar {
   display: flex;
   gap: 0.5rem;
-  margin-bottom: 1rem;
   flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+  .filter-bar {
+    flex-direction: column;
+  }
+
+  .filter-select-wrap {
+    width: 100%;
+  }
+}
+
+/* ── Filter select wrapper ── */
+.filter-select-wrap {
+  border-radius: 8px;
+  border: 2px solid transparent;
+  transition: border-color 0.15s ease;
+}
+
+.filter-select-wrap--active {
+  border-color: #304C89;
+  background-color: #eef2ff;
+  border-radius: 8px;
+}
+
+/* ── Filter selects ── */
+.filter-select {
+  height: 44px;
+  padding: 0 2.25rem 0 14px;
+  border: 1px solid #cfcfd6;
+  border-radius: 8px;
+  background: transparent;
+  color: #1f2430;
+  font: inherit;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg fill='none' stroke='%236b7280' stroke-width='2' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 0.9rem;
+  cursor: pointer;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.filter-select-wrap--active .filter-select {
+  border-color: transparent;
+  color: #1e3a8a;
+  font-weight: 500;
+  background-image: url("data:image/svg+xml;utf8,<svg fill='none' stroke='%231e3a8a' stroke-width='2' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><polyline points='6 9 12 15 18 9'/></svg>");
+}
+
+.filter-select:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(48, 76, 137, 0.2);
+}
+
+/* ── Status row ── */
+.filter-bar__status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.filter-bar__active-label {
+  font-size: 0.78rem;
+  color: #9ca3af;
+  letter-spacing: 0.01em;
+}
+
+.filter-bar__reset {
+  font-size: 0.78rem;
+  color: #304C89;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.filter-bar__reset:hover {
+  color: #1e3a8a;
 }


### PR DESCRIPTION
### Add active filter indicators and reset control
Currently, when filters are applied the task list silently shows fewer tasks with no visual explanation. This makes it easy to forget filters are active, especially relevant for users with ADHD who may not remember changing a filter earlier in the session.

### Changes
Active filter selects get a 2px indigo border and subtle tint, applied via a wrapper div to avoid native <select> styling interference
"Filters active" label appears below the filter row when any filter is non-default
"Reset filters" link appears alongside it and resets cognitive load, priority, and context back to "All" in one tap
Sort mode, view mode, and manual task order are explicitly excluded from the reset

### What wasn't changed
Show Completed and Show Snoozed are left out of the reset . These feel more like display preferences than filters. Open to revisiting if that's the wrong call.

No new filter types or grouping logic added per the spec