### PR TITLE
a11y: fix contrast, add missing labels and main landmark

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -115,7 +115,7 @@ button {
 }
 
 .empty-state {
-  opacity: 0.75;
+  color: #6b7280; /* was opacity: 0.75 on body text, which fell below 4.5:1; explicit color passes WCAG AA */
   margin-bottom: 1rem;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -594,6 +594,7 @@ if (!settingsLoaded) {
         </div>
       </header>
 
+      <main className="app-main">
       <section className="task-input">
         <TaskForm
           input={input}
@@ -869,6 +870,7 @@ if (!settingsLoaded) {
           ))}
         </ul>
       </section>
+      </main>
     </div>
   );
 }

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -27,6 +27,7 @@ function FilterBar({
             className={filterSelectClass}
             value={filterLoad}
             onChange={(e) => setFilterLoad(e.target.value)}
+            aria-label="Filter by cognitive load"
           >
             <option value="all">All cognitive loads</option>
             {Object.entries(loadLabels).map(([value, label]) => (
@@ -40,6 +41,7 @@ function FilterBar({
             className={filterSelectClass}
             value={filterPriority}
             onChange={(e) => setFilterPriority(e.target.value)}
+            aria-label="Filter by priority"
           >
             <option value="all">All priorities</option>
             {Object.entries(priorityLabels).map(([value, label]) => (
@@ -53,6 +55,7 @@ function FilterBar({
             className={filterSelectClass}
             value={filterContext}
             onChange={(e) => setFilterContext(e.target.value)}
+            aria-label="Filter by context"
           >
             <option value="all">All contexts</option>
             {contextOptions.map((option) => (

--- a/src/styles/task-form.css
+++ b/src/styles/task-form.css
@@ -17,7 +17,7 @@
 }
 
 .task-form-trigger__placeholder {
-  color: #9ca3af;
+  color: #6b7280; /* was #9ca3af (~2.85:1 contrast); #6b7280 passes WCAG AA at ~4.63:1 */
   font-size: 0.95rem;
 }
 


### PR DESCRIPTION
# a11y: Fix color contrast, missing labels, and main landmark

Addresses three accessibility failures flagged by Lighthouse (current score: **88**). All fixes target WCAG AA compliance.

## Changes

### `src/App.jsx`
Wrapped the primary page content in a `<main>` element. Without it, screen reader users have no landmark to navigate directly to the app content.

### `src/components/FilterBar.jsx`
Added `aria-label` attributes to all three filter `<select>` elements (`cognitive load`, `priority`, `context`). Unlabeled controls are announced without context by screen readers, making the filters unusable for assistive technology users.

### `src/styles/task-form.css`
Updated `.task-form-trigger__placeholder` text color from `#9ca3af` to `#6b7280`. The previous value had a contrast ratio of ~2.85:1 against white — well below the WCAG AA minimum of 4.5:1. The new value passes at ~4.63:1.

### `src/App.css`
Replaced `opacity: 0.75` on `.empty-state` with an explicit `color: #6b7280`. Opacity-based dimming is unpredictable across different background colors and can silently push text below contrast thresholds. An explicit color value is more robust and intentional.

## Testing
Run a Lighthouse accessibility audit before and after to confirm the score improves from 88 → 100.

closes #25 
closes #26 
closes #27 