### PR TITLE
seo: add meta description and update page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>cognitive-load-task-list</title>
+    <title>Cognitive Load Task Organizer</title>
+    <meta name="description" content="A task organizer that sorts your to-do list by cognitive load, priority, and context — so you always know what to work on next." />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
# seo: Add meta description and update page title

Two small fixes flagged by Lighthouse (current SEO score: **90**).

- Added `<meta name="description">` — was missing entirely, which prevents search engines from generating an accurate snippet
- Updated `<title>` from `cognitive-load-task-list` to `Cognitive Load Task Organizer` — more readable in browser tabs and search results

closes #30 