### PR TITLE
styling: adjust Momentum Mode panel component to style Momentum rela…

### DIFF
--- a/src/components/MomentumPanel.jsx
+++ b/src/components/MomentumPanel.jsx
@@ -30,7 +30,7 @@ function MomentumPanel({
             <div className="momentum-energy-options">
               <button
                 type="button"
-                className={momentumEnergy === "tired" ? "is-selected" : ""}
+                className={`momentum-energy-btn${momentumEnergy === "tired" ? " is-selected" : ""}`}
                 onClick={() => onSelectEnergy("tired")}
               >
                 Tired
@@ -38,7 +38,7 @@ function MomentumPanel({
 
               <button
                 type="button"
-                className={momentumEnergy === "normal" ? "is-selected" : ""}
+                className={`momentum-energy-btn${momentumEnergy === "normal" ? " is-selected" : ""}`}
                 onClick={() => onSelectEnergy("normal")}
               >
                 Normal
@@ -46,7 +46,7 @@ function MomentumPanel({
 
               <button
                 type="button"
-                className={momentumEnergy === "ambitious" ? "is-selected" : ""}
+                className={`momentum-energy-btn${momentumEnergy === "ambitious" ? " is-selected" : ""}`}
                 onClick={() => onSelectEnergy("ambitious")}
               >
                 Ambitious
@@ -59,11 +59,19 @@ function MomentumPanel({
           )}
 
           <div className="momentum-panel__actions">
-            <button type="button" onClick={onStartMomentumRun}>
+            <button
+              type="button"
+              className="momentum-btn momentum-btn--primary"
+              onClick={onStartMomentumRun}
+            >
               Start Momentum Run
             </button>
 
-            <button type="button" onClick={onPickKeystoneForMe}>
+            <button
+              type="button"
+              className="momentum-btn"
+              onClick={onPickKeystoneForMe}
+            >
               I&apos;m too tired, pick for me
             </button>
           </div>
@@ -80,7 +88,11 @@ function MomentumPanel({
               <p className="momentum-panel__help">
                 No lower-load tasks available in this context.
               </p>
-              <button type="button" onClick={onEnableCrossContextRunway}>
+              <button
+                type="button"
+                className="momentum-btn"
+                onClick={onEnableCrossContextRunway}
+              >
                 Bring in easier tasks from another context
               </button>
             </div>
@@ -96,9 +108,15 @@ function MomentumPanel({
             <p className="momentum-panel__error">{momentumError}</p>
           )}
 
-          <button type="button" onClick={onEndMomentumRun}>
-            End Run
-          </button>
+          <div className="momentum-panel__run-footer">
+            <button
+              type="button"
+              className="momentum-btn"
+              onClick={onEndMomentumRun}
+            >
+              End Run
+            </button>
+          </div>
         </>
       )}
     </div>

--- a/src/styles/momentum-panel.css
+++ b/src/styles/momentum-panel.css
@@ -20,23 +20,92 @@
   opacity: 0.75;
 }
 
+/* ── Energy option pills ── */
 .momentum-energy-options {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  margin-top: 0.4rem;
 }
 
-.momentum-energy-options .is-selected {
+.momentum-energy-btn {
+  height: 34px;
+  padding: 0 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: #fff;
+  color: #374151;
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.momentum-energy-btn:hover {
+  background: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.momentum-energy-btn.is-selected {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
   font-weight: 600;
 }
 
-.momentum-panel__error {
-  color: #b00020;
-  margin: 0.5rem 0;
+/* ── Shared action button base ── */
+.momentum-btn {
+  height: 36px;
+  padding: 0 1rem;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
 }
 
+.momentum-btn:hover {
+  background: #f3f4f6;
+}
+
+/* Primary variant */
+.momentum-btn--primary {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
+}
+
+.momentum-btn--primary:hover {
+  background: #1f2937;
+}
+
+/* ── Action row ── */
 .momentum-panel__actions {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+/* ── Error ── */
+.momentum-panel__error {
+  color: #b00020;
+  font-size: 0.875rem;
+  margin: 0.5rem 0 0.25rem;
+}
+
+/* ── Fallback / cross-context ── */
+.momentum-panel__fallback {
+  margin: 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+/* ── Active run footer ── */
+.momentum-panel__run-footer {
+  margin-top: 0.75rem;
 }


### PR DESCRIPTION
# Style Momentum Mode buttons

Previously all buttons in the Momentum Mode panel rendered as unstyled browser defaults. This PR applies consistent button styling throughout the panel.

## Changes

**`src/components/MomentumPanel.jsx`**
- Energy option buttons (Tired / Normal / Ambitious) get class `momentum-energy-btn`, with `is-selected` applied when active
- "Start Momentum Run" gets `momentum-btn momentum-btn--primary`
- "I'm too tired, pick for me", "Bring in easier tasks from another context", and "End Run" all get `momentum-btn`

**`src/styles/momentum-panel.css`**
- `.momentum-energy-btn` — pill-shaped, outlined by default, fills dark when selected
- `.momentum-btn` — standard outlined button matching the app's secondary button pattern
- `.momentum-btn--primary` — dark filled button for the primary action