### PR TITLE
style: style remaining unsnooze/momentum buttons by adding missing class

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -147,14 +147,18 @@ function TaskCard({
           )}
 
           {advancedFeaturesEnabled && isSnoozed && (
-            <button onClick={() => onUnsnooze(task.id)}>Un-snooze</button>
+            <button type="button" className="task-action-button" onClick={() => onUnsnooze(task.id)}>
+              Un-snooze
+            </button>
           )}
 
           {advancedFeaturesEnabled && momentumModeEnabled && !momentumRunActive && (
             isKeystone ? (
               <span className="keystone-badge">Keystone</span>
             ) : (
-              <button type="button" onClick={() => onSetKeystone(task.id)}>Set Keystone</button>
+              <button type="button" className="task-action-button" onClick={() => onSetKeystone(task.id)}>
+                Set Keystone
+              </button>
             )
           )}
 


### PR DESCRIPTION
### Description
Un-snooze and Set Keystone are both missing `className="task-action-button"`, which already exists and is already used by the Snooze button.

###Updates

- Two class additions in `TaskCard.jsx`
- Un-snooze and Set Keystone both now have `type="button" className="task-action-button"` which is the same class already used by the Snooze button

closes #14 