### PR TITLE
refactor: break FAQ out into modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import TaskCard from "./components/TaskCard";
 import FilterBar from "./components/FilterBar";
 import MomentumPanel from "./components/MomentumPanel";
 import SettingsModal from "./components/SettingsModal";
+import FAQModal from "./components/FAQModal";
 
 // Settings saver helper
 function persistSettings(settingsLoaded, settings) {
@@ -83,6 +84,7 @@ function App() {
   const [importError, setImportError] = useState(null);
   const [importSuccess, setImportSuccess] = useState(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [faqOpen, setFaqOpen] = useState(false);
 
   // Derive available context options
   const contextOptions = Array.from(
@@ -634,6 +636,15 @@ function App() {
         <div className="header-controls">
           <button
             type="button"
+            className="faq-trigger"
+            onClick={() => setFaqOpen(true)}
+            aria-label="Open FAQ"
+          >
+            ?
+          </button>
+
+          <button
+            type="button"
             className="settings-trigger"
             onClick={() => setSettingsOpen(true)}
             aria-label="Open settings"
@@ -661,6 +672,10 @@ function App() {
           </div>
         </div>
       </header>
+
+      {faqOpen && (
+        <FAQModal onClose={() => setFaqOpen(false)} />
+      )}
 
       {settingsOpen && (
         <SettingsModal

--- a/src/components/FAQModal.jsx
+++ b/src/components/FAQModal.jsx
@@ -1,0 +1,213 @@
+import { useEffect } from "react";
+import "../styles/faq-modal.css";
+
+function FAQModal({ onClose }) {
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="task-modal-backdrop"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="task-modal faq-modal" role="dialog" aria-label="FAQ">
+        <div className="task-modal__header">
+          <span className="faq-modal__title">FAQ</span>
+          <button
+            type="button"
+            className="task-modal__close"
+            onClick={onClose}
+            aria-label="Close FAQ"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="faq-modal__body">
+
+          <section className="faq-section">
+            <h2 className="faq-section__title">About this app</h2>
+
+            <div className="faq-item">
+              <p className="faq-item__q">What is the Cognitive Load Task Organizer?</p>
+              <p className="faq-item__a">
+                Most task managers ask you to sort by priority. This one asks a different question:
+                <em> what do you actually have the mental energy to do right now?</em> Tasks are
+                categorized by cognitive load — the mental effort they require — so you can pick
+                something that matches how you're feeling, not just what's theoretically most important.
+                It's designed to be useful for anyone dealing with fatigue, ADHD, executive dysfunction,
+                or just a rough day.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <p className="faq-item__q">What do the load levels mean?</p>
+              <p className="faq-item__a">
+                <strong>Low load</strong> — routine, low-effort tasks. "Reply to that email." "Put laundry in the dryer."<br />
+                <strong>Medium load</strong> — moderate effort, some focus required. "Sort through the mail." "Write a shopping list."<br />
+                <strong>High load</strong> — deep focus, significant mental energy. "Write the report." "Do taxes."
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <p className="faq-item__q">What is Momentum Mode?</p>
+              <p className="faq-item__a">
+                Momentum Mode is an experimental feature (enable it under Advanced Features) that helps
+                you build a working rhythm when starting feels hard. You pick a Keystone task — something
+                meaningful you want to anchor your session around — and tell the app how much energy you
+                have. It then sequences your tasks to warm you up gradually rather than throwing you
+                straight into the deep end. It's loosely inspired by the idea that starting small builds
+                momentum toward harder things.
+              </p>
+            </div>
+          </section>
+
+          <section className="faq-section">
+            <h2 className="faq-section__title">Your data</h2>
+
+            <div className="faq-item">
+              <p className="faq-item__q">Why don't I need to log in?</p>
+              <p className="faq-item__a">
+                Your tasks never leave your device. There's no account, no server, no database in the
+                cloud. Everything is stored directly in your browser using IndexedDB — the same technology
+                browsers use to store offline data for web apps. No login needed because there's nothing
+                to authenticate against.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <p className="faq-item__q">What is IndexedDB, and why use it instead of just saving to a file?</p>
+              <p className="faq-item__a">
+                IndexedDB is a built-in browser database. Unlike localStorage (which has a small size
+                limit and stores everything as plain text), IndexedDB handles structured data, is
+                asynchronous so it doesn't slow the app down, and scales gracefully as your task list
+                grows. Your data persists between sessions automatically — you don't have to do anything
+                to save it.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <p className="faq-item__q">What happens if I clear my browser data?</p>
+              <p className="faq-item__a">
+                Your tasks will be deleted. Browser data clears (cookies, cache, site data) will wipe
+                IndexedDB along with everything else. If you want a backup, use Export in Settings before
+                clearing. This is also why using the app across multiple devices requires manually
+                importing/exporting — there's no sync layer.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <p className="faq-item__q">Is my data private?</p>
+              <p className="faq-item__a">
+                Yes — it never leaves your browser. No analytics, no tracking, no server ever sees your
+                tasks. The trade-off is that there's no backup either. Don't store anything you'd be
+                devastated to lose without having exported it first. Also worth noting: IndexedDB is
+                stored in plaintext, so if someone has access to your device and knows what they're
+                looking for, they could read it.
+              </p>
+            </div>
+          </section>
+
+          <section className="faq-section">
+            <h2 className="faq-section__title">Import &amp; Export</h2>
+
+            <div className="faq-item">
+              <p className="faq-item__q">How does Export work?</p>
+              <p className="faq-item__a">
+                Export (in Settings) downloads a <code>.json</code> file containing all your tasks and
+                settings. You can use this as a backup, or to move your data to another browser or device
+                by importing it there.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <p className="faq-item__q">How does Import work?</p>
+              <p className="faq-item__a">
+                Import reads a <code>.json</code> file you previously exported from this app. You'll be
+                asked whether to <strong>Replace</strong> (wipe everything and start fresh from the file)
+                or <strong>Merge</strong> (add the imported tasks alongside your existing ones). In merge
+                mode, if an imported task has the same ID as one you've already edited locally, the
+                imported version will overwrite your local edits — so only merge when you know what
+                you're bringing in.
+              </p>
+            </div>
+
+            <div className="faq-item faq-item--warning">
+              <p className="faq-item__q">⚠️ Don't import files you don't recognise</p>
+              <p className="faq-item__a">
+                Only import <code>.json</code> files that you exported from this app yourself. Importing
+                an unknown file could overwrite or corrupt your task data. The app validates the format
+                before importing, but it can't protect you from intentionally crafted bad data. When in
+                doubt, export a backup of your current tasks first, then import.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <p className="faq-item__q">Can I use this across multiple devices?</p>
+              <p className="faq-item__a">
+                Yes, but manually. Export from one device, import on the other. There's no automatic
+                sync — that would require a server and an account, which this app intentionally doesn't
+                have. For most people, a periodic export is enough.
+              </p>
+            </div>
+          </section>
+
+          <section className="faq-section faq-section--links">
+            <h2 className="faq-section__title">Further reading &amp; links</h2>
+
+            <div className="faq-links">
+              <a
+                href="https://hanasays.myportfolio.com/cognitive-load-task-organizer"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="faq-link"
+              >
+                Case study — design process &amp; decisions
+              </a>
+              <a
+                href="https://github.com/martinson-r/Cognitive-Load-Task-Organizer"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="faq-link"
+              >
+                Source code on GitHub
+              </a>
+              <a
+                href="https://en.wikipedia.org/wiki/Cognitive_load"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="faq-link"
+              >
+                Cognitive load — Wikipedia overview
+              </a>
+              <a
+                href="https://www.understood.org/en/articles/cognitive-load-what-it-is-why-it-matters"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="faq-link"
+              >
+                Cognitive load and ADHD/executive function — Understood.org
+              </a>
+              <a
+                href="https://www.nngroup.com/articles/minimize-cognitive-load/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="faq-link"
+              >
+                Minimising cognitive load in UX — Nielsen Norman Group
+              </a>
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default FAQModal;

--- a/src/styles/faq-modal.css
+++ b/src/styles/faq-modal.css
@@ -1,0 +1,138 @@
+.faq-modal {
+  max-width: 560px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.faq-modal__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.faq-modal__body {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding-right: 0.25rem; /* breathing room from scrollbar */
+}
+
+/* ── Sections ── */
+.faq-section {
+  padding: 1.1rem 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.faq-section:first-child {
+  padding-top: 0;
+}
+
+.faq-section:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.faq-section__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+  margin: 0 0 0.85rem;
+}
+
+/* ── Items ── */
+.faq-item {
+  margin-bottom: 1rem;
+}
+
+.faq-item:last-child {
+  margin-bottom: 0;
+}
+
+.faq-item__q {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 0.3rem;
+}
+
+.faq-item__a {
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.faq-item__a code {
+  font-size: 0.8rem;
+  background: #f3f4f6;
+  padding: 1px 5px;
+  border-radius: 4px;
+  color: #374151;
+}
+
+.faq-item__a strong {
+  color: #111827;
+}
+
+/* ── Warning item ── */
+.faq-item--warning .faq-item__q {
+  color: #92400e;
+}
+
+.faq-item--warning .faq-item__a {
+  color: #78350f;
+}
+
+/* ── Links section ── */
+.faq-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.faq-link {
+  font-size: 0.875rem;
+  color: #2563eb;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.faq-link:hover {
+  text-decoration: underline;
+  color: #1d4ed8;
+}
+
+.faq-link::after {
+  content: "↗";
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+/* ── Help trigger button in header ── */
+.faq-trigger {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.faq-trigger:hover {
+  background: #f3f4f6;
+  color: #111827;
+}


### PR DESCRIPTION
# Add FAQ modal

Adds a `?` button to the header that opens a scrollable FAQ modal covering the app's purpose, data storage, import/export behaviour, and further reading.

## Changes

**New: `src/components/FAQModal.jsx`**
- Four sections: About this app, Your data, Import & Export, Further reading & links
- Reuses existing `.task-modal` / `.task-modal-backdrop` patterns
- Closes on Escape or backdrop click

**New: `src/styles/faq-modal.css`**
- Scrollable modal body with max-height
- Section and item typography styles
- Warning item variant for the "don't import mystery files" callout
- External link styles with `↗` indicator
- `.faq-trigger` button style matching the existing `.settings-trigger`

**`src/App.jsx`**
- `FAQModal` imported and wired up
- `faqOpen` state added
- `?` button added to header, left of the gear

## Content covered

- What the app is and why cognitive load instead of priority
- What Low / Medium / High load levels mean in practice
- What Momentum Mode is and how it works
- Why there's no login and how IndexedDB works in plain language
- What happens if browser data is cleared
- Privacy: data never leaves the device, stored in plaintext
- How Export works
- How Import works (replace vs merge, ID behaviour)
- Warning: only import files you exported yourself
- Multi-device workflow (manual export/import)
- Links: case study, GitHub repo, Wikipedia on cognitive load, Understood.org (ADHD/executive function), Nielsen Norman Group (cognitive load in UX)