### PR TITLE
style: Adjust rolldown  border color to be less obtrusive

### DIFF
--- a/src/styles/filter-bar.css
+++ b/src/styles/filter-bar.css
@@ -8,8 +8,8 @@
 }
 
 .filter-bar-wrapper--active {
-  border-color: rgb(143, 0, 0);
-  background-color: rgb(250, 240, 240);
+  border-color: #d9d9d9;
+  background-color: rgb(250, 248, 240);
 }
 
 /* ── Header bar ── */


### PR DESCRIPTION
## Change:
- border and background on Filter Bar changed to:
```
border-color: #d9d9d9;
background-color: rgb(250, 248, 240);
```