### PR TITLE
style: cleanup pass and polish, add additional content to UI Guide

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -120,8 +120,8 @@ button {
   padding: 0 var(--space-2);
   border: 1px solid var(--border-input);
   border-radius: var(--radius-input);
-  background: var(--bg);
-  color: var(--text-h);
+  background: var(--surface-base);
+  color: var(--text-primary);
   box-sizing: border-box;
 }
 
@@ -212,7 +212,7 @@ button {
 }
 
 .mode-pill[aria-pressed="true"] {
-  background: var(--bg);
+  background: var(--surface-base);
   color: var(--text-primary);
   box-shadow: var(--shadow-sm);
 }
@@ -498,7 +498,7 @@ button {
   padding: 0 var(--space-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-button);
-  background: var(--bg);
+  background: var(--surface-base);
   color: var(--text-secondary);
   font: inherit;
   font-size: var(--font-chip-mobile-size);

--- a/src/components/UIGuide.jsx
+++ b/src/components/UIGuide.jsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import "../App.css";
 import "../styles/ui-guide.css";
 
-// ── Helper Components for Documentation ──
+// ── Helper Components ──────────────────────────────────────────────────────
 
 function ColorToken({ varName, hex, usage, border = false }) {
   const background = varName ? `var(${varName})` : hex;
@@ -10,12 +10,12 @@ function ColorToken({ varName, hex, usage, border = false }) {
 
   return (
     <div className="token-card">
-      <div 
-        className="token-card__preview" 
-        style={{ 
-          background: background,
-          borderBottom: border ? "none" : "1px solid var(--border-default)"
-        }} 
+      <div
+        className="token-card__preview"
+        style={{
+          background,
+          borderBottom: border ? "none" : "1px solid var(--border-default)",
+        }}
       />
       <div className="token-card__details">
         <code className="token-card__name">{label}</code>
@@ -28,7 +28,7 @@ function ColorToken({ varName, hex, usage, border = false }) {
 function TypeToken({ name, sizeVar, lineVar, weight = "400", usage }) {
   return (
     <div className="type-specimen">
-      <p 
+      <p
         className="type-specimen__demo"
         style={{ fontSize: `var(${sizeVar})`, lineHeight: `var(${lineVar})`, fontWeight: weight }}
       >
@@ -37,6 +37,7 @@ function TypeToken({ name, sizeVar, lineVar, weight = "400", usage }) {
       <div className="type-specimen__meta">
         <span>Size: <code>{sizeVar}</code></span>
         <span>Line: <code>{lineVar}</code></span>
+        <span>Weight: <code>{weight}</code></span>
       </div>
       <p className="token-card__usage" style={{ marginTop: "4px" }}>{usage}</p>
     </div>
@@ -86,9 +87,9 @@ function ShadowToken({ varName, usage, borderRadius = "var(--radius-card)" }) {
   return (
     <div className="token-card">
       <div className="token-card__preview token-card__preview--shadow">
-        <div 
-          className="token-card__preview-box" 
-          style={{ boxShadow: `var(${varName})`, borderRadius }} 
+        <div
+          className="token-card__preview-box"
+          style={{ boxShadow: `var(${varName})`, borderRadius }}
         />
       </div>
       <div className="token-card__details">
@@ -99,27 +100,29 @@ function ShadowToken({ varName, usage, borderRadius = "var(--radius-card)" }) {
   );
 }
 
-// ── Main Guide Page ──
+// ── Main Guide ─────────────────────────────────────────────────────────────
 
 function UIGuide() {
   const sections = [
-    { id: "typography", label: "Typography" },
-    { id: "spacing", label: "Spacing" },
-    { id: "radius", label: "Radius" },
-    { id: "surfaces", label: "Surfaces" },
-    { id: "text-icons", label: "Text & Icons" },
-    { id: "load-tokens", label: "Cognitive Load" },
+    { id: "typography",      label: "Typography" },
+    { id: "spacing",         label: "Spacing" },
+    { id: "radius",          label: "Radius" },
+    { id: "surfaces",        label: "Surfaces" },
+    { id: "borders",         label: "Borders" },
+    { id: "text-tokens",     label: "Text" },
+    { id: "icon-tokens",     label: "Icons" },
+    { id: "load-tokens",     label: "Cognitive Load" },
     { id: "priority-tokens", label: "Priority" },
-    { id: "context-colors", label: "Context Colors" },
-    { id: "system-states", label: "System States" },
-    { id: "elevation", label: "Elevation" },
+    { id: "context-colors",  label: "Context Colors" },
+    { id: "action-tokens",   label: "Actions" },
+    { id: "system-states",   label: "System States" },
+    { id: "feature-tokens",  label: "Feature Tokens" },
+    { id: "elevation",       label: "Elevation" },
   ];
 
   const scrollToSection = (id) => {
     const element = document.getElementById(id);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth" });
-    }
+    if (element) element.scrollIntoView({ behavior: "smooth" });
   };
 
   return (
@@ -127,29 +130,22 @@ function UIGuide() {
       <header className="app-header">
         <h1>UI Implementation Guide</h1>
         <div className="header-controls">
-          <Link to="/" className="data-btn" style={{ textDecoration: 'none' }}>
+          <Link to="/" className="data-btn" style={{ textDecoration: "none" }}>
             ← Back to App
           </Link>
         </div>
       </header>
 
       <main className="ui-guide-grid">
-        {/* Table of Contents - Docks to top on mobile, Sticky on desktop */}
+        {/* Table of Contents */}
         <nav className="ui-guide-toc">
           <p className="ui-guide-toc__label">Contents</p>
           <div className="ui-guide-toc__links">
             {sections.map(s => (
-              <button 
-                key={s.id} 
-                onClick={() => scrollToSection(s.id)} 
+              <button
+                key={s.id}
+                onClick={() => scrollToSection(s.id)}
                 className="ui-guide-toc__link"
-                style={{ 
-                  background: 'none', 
-                  border: 'none', 
-                  padding: 0, 
-                  cursor: 'pointer',
-                  textAlign: 'left' 
-                }}
               >
                 {s.label}
               </button>
@@ -160,84 +156,124 @@ function UIGuide() {
         <div className="ui-guide-content">
           <div className="info-banner">
             <p>
-              <strong>Developer Note:</strong> This document outlines the CSS variables (tokens) that form the single source of truth for the application's UI. <strong>Do not use hardcoded hex values or RGBA strings in components.</strong>
+              <strong>Developer note:</strong> All values below are CSS custom properties defined in <code>App.css</code>. <strong>Do not use hardcoded hex values or rgba strings in components.</strong> If a value you need isn't here, add a token first.
             </p>
           </div>
 
+          {/* ── Typography ── */}
           <section id="typography" className="ui-guide-section">
             <h2>Typography</h2>
             <div className="type-specimen-list">
-              <TypeToken name="Title Large (H1)" sizeVar="--font-title-lg-size" lineVar="--font-title-lg-line" weight="500" usage="App header title." />
-              <TypeToken name="Primary Body" sizeVar="--font-primary-size" lineVar="--font-primary-line" usage="Standard inputs, task titles." />
-              <TypeToken name="Chip / Mobile" sizeVar="--font-chip-mobile-size" lineVar="--font-chip-mobile-line" usage="Tags, pills, meta-info." />
+              <TypeToken name="Title Large" sizeVar="--font-title-lg-size" lineVar="--font-title-lg-line" weight="500" usage="App header H1." />
+              <TypeToken name="Title Small" sizeVar="--font-title-sm-size" lineVar="--font-title-sm-line" weight="500" usage="Section headers, modal titles." />
+              <TypeToken name="Primary Body" sizeVar="--font-primary-size" lineVar="--font-primary-line" usage="Standard inputs, task titles, toggle labels." />
+              <TypeToken name="Chip / Label" sizeVar="--font-chip-mobile-size" lineVar="--font-chip-mobile-line" usage="Tags, pills, meta info, button labels, small UI text." />
             </div>
           </section>
 
+          {/* ── Spacing ── */}
           <section id="spacing" className="ui-guide-section">
             <h2>Spacing</h2>
             <div className="token-grid">
-              <SpaceToken varName="--space-1" usage="8px — Tight gaps." />
-              <SpaceToken varName="--space-2" usage="16px — Standard padding." />
-              <SpaceToken varName="--space-3" usage="24px — Loose padding." />
+              <SpaceToken varName="--space-1" usage="8px — Tight gaps, icon padding." />
+              <SpaceToken varName="--space-2" usage="16px — Standard padding, form gaps." />
+              <SpaceToken varName="--space-3" usage="24px — Section gaps (app-main gap)." />
+              <SpaceToken varName="--space-4" usage="32px — Page padding, large blocks." />
             </div>
           </section>
 
+          {/* ── Radius ── */}
           <section id="radius" className="ui-guide-section">
             <h2>Border Radius</h2>
             <div className="token-grid">
-              <RadiusToken varName="--radius-button" usage="6px — Buttons." />
-              <RadiusToken varName="--radius-modal" usage="16px — Modals." />
-              <RadiusToken varName="--radius-pill" usage="999px — Badges/Toggles." />
+              <RadiusToken varName="--radius-button" usage="6px — Buttons, small controls." />
+              <RadiusToken varName="--radius-input" usage="8px — Inputs, select wrappers, cards." />
+              <RadiusToken varName="--radius-card" usage="8px — Task cards, panels." />
+              <RadiusToken varName="--radius-modal" usage="16px — Modals, bottom sheets." />
+              <RadiusToken varName="--radius-pill" usage="999px — Pills, toggles, badges." />
             </div>
           </section>
 
+          {/* ── Surfaces ── */}
           <section id="surfaces" className="ui-guide-section">
             <h2>Surfaces</h2>
+            <p className="ui-guide-desc">Background layers in order of visual depth. Use these instead of hardcoded whites and near-whites.</p>
             <div className="token-grid">
-              <ColorToken varName="--bg" usage="Body background." />
-              <ColorToken varName="--surface-base" usage="Standard component background." />
-              <ColorToken varName="--surface-subtle" usage="Secondary panels." />
+              <ColorToken varName="--surface-base" usage="Default component background. Cards, modals, inputs." />
+              <ColorToken varName="--surface-subtle" usage="Slightly off-white panels. Task input, momentum panel." border />
+              <ColorToken varName="--surface-light" usage="Hover states, done-task backgrounds." border />
+              <ColorToken varName="--surface-muted" usage="Dividers, disabled fills, toggle track off." />
+              <ColorToken varName="--surface-toggle-on" usage="Active toggle track. Dark filled buttons." />
+              <ColorToken varName="--surface-toggle-hover" usage="Dark filled button hover — slightly lighter than toggle-on." />
             </div>
           </section>
 
-          <section id="text-icons" className="ui-guide-section">
-            <h2>Text & Icons</h2>
+          {/* ── Borders ── */}
+          <section id="borders" className="ui-guide-section">
+            <h2>Borders</h2>
             <div className="token-grid">
-              <ColorToken varName="--text-h" usage="Headings." />
-              <ColorToken varName="--text-primary" usage="Body copy." />
-              <ColorToken varName="--text-tertiary" usage="Low contrast placeholders." />
+              <ColorToken varName="--border-default" usage="Card borders, dividers, section lines." />
+              <ColorToken varName="--border-strong" usage="Input borders, button outlines, select wrappers." />
+              <ColorToken varName="--border-input" usage="Native input and filter select borders. Slightly softer than border-strong." />
+              <ColorToken varName="--border-button-subtle" usage="Subtle button outline variant." />
             </div>
           </section>
 
+          {/* ── Text ── */}
+          <section id="text-tokens" className="ui-guide-section">
+            <h2>Text</h2>
+            <div className="token-grid">
+              <ColorToken varName="--text-primary" usage="Headings, task titles, strong labels." />
+              <ColorToken varName="--text-secondary" usage="Body copy, descriptions, button labels." />
+              <ColorToken varName="--text-tertiary" usage="Muted text, placeholders, helper labels." />
+              <ColorToken varName="--text-highlight" usage="Text on dark/filled surfaces (toggle, primary buttons)." />
+              <ColorToken varName="--text-button-subtle" usage="Secondary button label." />
+            </div>
+          </section>
+
+          {/* ── Icons ── */}
+          <section id="icon-tokens" className="ui-guide-section">
+            <h2>Icons</h2>
+            <p className="ui-guide-desc">Move-button arrows use <code>--icon</code>. Edit and delete icons use <code>--icon-subtle</code> to read lighter against the bare (no border box) background.</p>
+            <div className="token-grid">
+              <ColorToken varName="--icon" usage="Move-button arrows and bordered icon buttons." />
+              <ColorToken varName="--icon-hover" usage="Icon color on hover." />
+              <ColorToken varName="--icon-subtle" usage="Edit and delete icons — bare, no border box." />
+            </div>
+          </section>
+
+          {/* ── Load ── */}
           <section id="load-tokens" className="ui-guide-section">
-            <h2>Cognitive Load Tokens</h2>
-            <p className="ui-guide-desc">Semantic tokens mapped to task effort levels.</p>
+            <h2>Cognitive Load</h2>
+            <p className="ui-guide-desc">Semantic tokens mapped to task effort levels. Always use the paired bg + text tokens together.</p>
             <div className="token-grid">
-              <ColorToken varName="--load-low-bg" usage="Low Load background." border />
-              <ColorToken varName="--load-low" usage="Low Load text/icon." />
-              <ColorToken varName="--load-medium-bg" usage="Med Load background." border />
-              <ColorToken varName="--load-medium" usage="Med Load text/icon." />
-              <ColorToken varName="--load-high-bg" usage="High Load background." border />
-              <ColorToken varName="--load-high" usage="High Load text/icon." />
+              <ColorToken varName="--load-low-bg" usage="Low load pill background." border />
+              <ColorToken varName="--load-low" usage="Low load pill text / icon." />
+              <ColorToken varName="--load-medium-bg" usage="Med load pill background." border />
+              <ColorToken varName="--load-medium" usage="Med load pill text / icon." />
+              <ColorToken varName="--load-high-bg" usage="High load pill background." border />
+              <ColorToken varName="--load-high" usage="High load pill text / icon." />
             </div>
           </section>
 
+          {/* ── Priority ── */}
           <section id="priority-tokens" className="ui-guide-section">
-            <h2>Priority Tokens</h2>
-            <p className="ui-guide-desc">Semantic tokens mapped to task urgency levels.</p>
+            <h2>Priority</h2>
+            <p className="ui-guide-desc">Semantic tokens mapped to task urgency levels. Always use the paired bg + text tokens together.</p>
             <div className="token-grid">
-              <ColorToken varName="--priority-low-bg" usage="Low Priority background." border />
-              <ColorToken varName="--priority-low" usage="Low Priority text/icon." />
-              <ColorToken varName="--priority-medium-bg" usage="Med Priority background." border />
-              <ColorToken varName="--priority-medium" usage="Med Priority text/icon." />
-              <ColorToken varName="--priority-high-bg" usage="High Priority background." border />
-              <ColorToken varName="--priority-high" usage="High Priority text/icon." />
+              <ColorToken varName="--priority-low-bg" usage="Low priority pill background." border />
+              <ColorToken varName="--priority-low" usage="Low priority pill text / icon." />
+              <ColorToken varName="--priority-medium-bg" usage="Med priority pill background." border />
+              <ColorToken varName="--priority-medium" usage="Med priority pill text / icon." />
+              <ColorToken varName="--priority-high-bg" usage="High priority pill background." border />
+              <ColorToken varName="--priority-high" usage="High priority pill text / icon." />
             </div>
           </section>
 
+          {/* ── Context ── */}
           <section id="context-colors" className="ui-guide-section">
-            <h2>Context Chips (Presets)</h2>
-            <p className="ui-guide-desc">Dynamic preset colors defined in <code>TaskOptions.jsx</code>.</p>
+            <h2>Context Chips</h2>
+            <p className="ui-guide-desc">Preset context colors are defined in <code>TaskOptions.jsx</code>, not as CSS tokens, because they are data-driven. Custom contexts are assigned from a deterministic hash pool.</p>
             <div className="token-grid">
               <ColorToken hex="#fef3c7" usage="Kitchen" border />
               <ColorToken hex="#ccfbf1" usage="Bathroom" border />
@@ -248,25 +284,72 @@ function UIGuide() {
               <ColorToken hex="#dcfce7" usage="Outside" border />
               <ColorToken hex="#e0f2fe" usage="Laundry" border />
               <ColorToken hex="#ffe4e6" usage="Admin" border />
-              <ColorToken hex="#f3f4f6" usage="General (Default)" border />
+              <ColorToken hex="#f3f4f6" usage="General (default)" border />
             </div>
           </section>
 
+          {/* ── Actions ── */}
+          <section id="action-tokens" className="ui-guide-section">
+            <h2>Actions</h2>
+            <p className="ui-guide-desc">Used exclusively for edit and delete icon hover states.</p>
+            <div className="token-grid">
+              <ColorToken varName="--action-edit" usage="Edit icon hover color." />
+              <ColorToken varName="--action-delete" usage="Delete icon hover color." />
+            </div>
+          </section>
+
+          {/* ── System States ── */}
           <section id="system-states" className="ui-guide-section">
             <h2>System States</h2>
             <div className="token-grid">
-              <ColorToken varName="--color-success" usage="Success states." />
-              <ColorToken varName="--color-danger" usage="Errors/Destructive." />
-              <ColorToken varName="--color-warning" usage="Warning banners." />
+              <ColorToken varName="--color-success" usage="Import success, positive feedback." />
+              <ColorToken varName="--color-danger" usage="Errors, destructive action labels." />
+              <ColorToken varName="--color-danger-bg" usage="Danger button/section background." border />
+              <ColorToken varName="--color-danger-border" usage="Danger button borders." />
+              <ColorToken varName="--color-warning" usage="Warning banners and text (FAQ)." />
+              <ColorToken varName="--color-link" usage="Hyperlink text." />
+              <ColorToken varName="--color-link-hover" usage="Hyperlink hover." />
             </div>
           </section>
 
+          {/* ── Feature Tokens ── */}
+          <section id="feature-tokens" className="ui-guide-section">
+            <h2>Feature Tokens</h2>
+            <p className="ui-guide-desc">Tokens tied to specific product features. Isolating them means global palette changes don't accidentally affect feature states.</p>
+
+            <h3 className="ui-guide-subheading">Snoozed Tasks</h3>
+            <div className="token-grid">
+              <ColorToken varName="--surface-snoozed" usage="Snoozed task card background." border />
+              <ColorToken varName="--border-snoozed" usage="Snoozed task card border." />
+            </div>
+
+            <h3 className="ui-guide-subheading">Active Filters</h3>
+            <div className="token-grid">
+              <ColorToken varName="--surface-filter-active" usage="Active filter select wrapper background." border />
+              <ColorToken varName="--surface-filter-wrapper" usage="Filter bar wrapper background when filters active." border />
+              <ColorToken varName="--color-filter-active" usage="Active filter label and caret color." />
+              <ColorToken varName="--color-filter-active-hover" usage="Filter reset button hover color." />
+            </div>
+
+            <h3 className="ui-guide-subheading">Keystone Task (Momentum Mode)</h3>
+            <div className="token-grid">
+              <ColorToken varName="--color-keystone" usage="Keystone task card background highlight." />
+            </div>
+          </section>
+
+          {/* ── Elevation ── */}
           <section id="elevation" className="ui-guide-section">
             <h2>Shadows & Overlays</h2>
             <div className="token-grid">
-              <ShadowToken varName="--shadow-sm" usage="Buttons." />
-              <ShadowToken varName="--shadow-md" usage="Dropdowns." />
-              <ColorToken varName="--backdrop-overlay" usage="Modals." />
+              <ShadowToken varName="--shadow-sm" usage="Subtle lift. Active mode-strip pill." />
+              <ShadowToken varName="--shadow-md" usage="Dropdowns, submenus." />
+              <ShadowToken varName="--shadow-modal-mobile" usage="Bottom sheet modal (mobile)." borderRadius="var(--radius-modal) var(--radius-modal) 0 0" />
+              <ShadowToken varName="--shadow-modal-desktop" usage="Centered modal (desktop)." borderRadius="var(--radius-modal)" />
+            </div>
+            <h3 className="ui-guide-subheading">Backdrop Overlays</h3>
+            <div className="token-grid">
+              <ColorToken varName="--backdrop-overlay" usage="Standard modal backdrop (task form, settings)." />
+              <ColorToken varName="--backdrop-overlay-dark" usage="Deeper backdrop for sub-modals (segment picker)." />
             </div>
           </section>
         </div>

--- a/src/styles/faq-modal.css
+++ b/src/styles/faq-modal.css
@@ -9,7 +9,7 @@
   font-size: var(--font-section-size);
   line-height: var(--font-section-line);
   font-weight: 600;
-  color: var(--text-h);
+  color: var(--text-primary);
 }
 
 .faq-modal__body {
@@ -52,21 +52,21 @@
 }
 
 .faq-item__q {
-  font-size: 0.9rem;
+  font-size: var(--font-chip-mobile-size);
   font-weight: 600;
-  color: var(--text-h);
+  color: var(--text-primary);
   margin: 0 0 var(--space-2);
 }
 
 .faq-item__a {
-  font-size: 0.875rem;
+  font-size: var(--font-chip-mobile-size);
   color: var(--text-secondary);
   line-height: 1.6;
   margin: 0;
 }
 
 .faq-item__a code {
-  font-size: 0.8rem;
+  font-size: var(--font-chip-mobile-size);
   background: var(--surface-light);
   padding: 1px 5px;
   border-radius: var(--radius-input);
@@ -74,7 +74,7 @@
 }
 
 .faq-item__a strong {
-  color: var(--text-h);
+  color: var(--text-primary);
 }
 
 .faq-item--warning .faq-item__q {
@@ -88,11 +88,11 @@
 .faq-links {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: var(--space-1);
 }
 
 .faq-link {
-  font-size: 0.875rem;
+  font-size: var(--font-chip-mobile-size);
   color: var(--color-link);
   text-decoration: none;
   display: inline-flex;
@@ -116,19 +116,19 @@
   height: 32px;
   border-radius: var(--radius-button);
   border: 1px solid var(--border-strong);
-  background: var(--bg);
+  background: var(--surface-base);
   color: var(--text-tertiary);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   flex-shrink: 0;
-  font-size: 0.9rem;
+  font-size: var(--font-chip-mobile-size);
   font-weight: 700;
   transition: background 0.15s ease, color 0.15s ease;
 }
 
 .faq-trigger:hover {
   background: var(--surface-light);
-  color: var(--text-h);
+  color: var(--text-primary);
 }

--- a/src/styles/filter-bar.css
+++ b/src/styles/filter-bar.css
@@ -141,7 +141,7 @@
   border: 1px solid var(--border-input);
   border-radius: var(--radius-input);
   background: transparent;
-  color: var(--text-h);
+  color: var(--text-primary);
   font: inherit;
   appearance: none;
   -webkit-appearance: none;

--- a/src/styles/momentum-panel.css
+++ b/src/styles/momentum-panel.css
@@ -33,7 +33,7 @@
   padding: 0 var(--space-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-pill);
-  background: var(--bg);
+  background: var(--surface-base);
   color: var(--text-secondary);
   font: inherit;
   font-size: var(--font-chip-mobile-size);
@@ -59,7 +59,7 @@
   padding: 0 var(--space-2);
   border-radius: var(--radius-button);
   border: 1px solid var(--border-strong);
-  background: var(--bg);
+  background: var(--surface-base);
   color: var(--text-secondary);
   font: inherit;
   font-size: var(--font-chip-mobile-size);

--- a/src/styles/settings-modal.css
+++ b/src/styles/settings-modal.css
@@ -6,13 +6,13 @@
   font-size: var(--font-section-size);
   line-height: var(--font-section-line);
   font-weight: 600;
-  color: var(--text-h);
+  color: var(--text-primary);
 }
 
 .settings-modal__section {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: var(--space-1);
 }
 
 .settings-modal__section + .settings-modal__section {
@@ -26,7 +26,7 @@
 }
 
 .settings-modal__section-title {
-  font-size: 0.8rem;
+  font-size: var(--font-chip-mobile-size);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -39,7 +39,7 @@
 }
 
 .settings-modal__section-desc {
-  font-size: 0.875rem;
+  font-size: var(--font-chip-mobile-size);
   color: var(--text-tertiary);
   margin: 0;
   line-height: 1.5;
@@ -56,10 +56,10 @@
   padding: 0 var(--space-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-button);
-  background: var(--bg);
+  background: var(--surface-base);
   color: var(--text-secondary);
   font: inherit;
-  font-size: 0.875rem;
+  font-size: var(--font-chip-mobile-size);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -85,7 +85,7 @@
   height: 32px;
   border-radius: var(--radius-button);
   border: 1px solid var(--border-strong);
-  background: var(--bg);
+  background: var(--surface-base);
   color: var(--text-tertiary);
   display: flex;
   align-items: center;
@@ -97,7 +97,7 @@
 
 .settings-trigger:hover {
   background: var(--surface-light);
-  color: var(--text-h);
+  color: var(--text-primary);
 }
 
 .settings-trigger svg {

--- a/src/styles/task-card.css
+++ b/src/styles/task-card.css
@@ -13,7 +13,7 @@
   border-radius: var(--radius-card);
   margin-bottom: var(--space-2);
   border: 1px solid var(--border-default);
-  background: var(--bg);
+  background: var(--surface-base);
 }
 
 .task-content {
@@ -43,7 +43,7 @@
   font-weight: 500;
   font-size: var(--font-primary-size);
   line-height: var(--font-primary-line);
-  color: var(--text-h);
+  color: var(--text-primary);
 }
 
 .task-item--done .task-title {
@@ -122,7 +122,7 @@
   padding: var(--space-1);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-button);
-  background: var(--bg);
+  background: var(--surface-base);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -151,7 +151,7 @@
   border: 1px solid var(--border-input);
   border-radius: var(--radius-button);
   font: inherit;
-  background: var(--bg);
+  background: var(--surface-base);
 }
 
 .edit-input {
@@ -192,7 +192,7 @@
 }
 
 .cancel-button {
-  background: var(--bg);
+  background: var(--surface-base);
 }
 
 .cancel-button:hover {
@@ -221,7 +221,7 @@
   padding: 0 var(--space-2);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-button);
-  background: var(--bg);
+  background: var(--surface-base);
   font-size: var(--font-chip-mobile-size);
   line-height: var(--font-chip-mobile-line);
   cursor: pointer;
@@ -242,7 +242,7 @@
   padding: var(--space-1);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-input);
-  background: var(--bg);
+  background: var(--surface-base);
   box-shadow: var(--shadow-md);
 }
 

--- a/src/styles/task-form.css
+++ b/src/styles/task-form.css
@@ -6,7 +6,7 @@
   padding: 0 var(--space-2);
   border: 1px solid var(--border-input);
   border-radius: var(--radius-input);
-  background: var(--bg);
+  background: var(--surface-base);
   cursor: text;
   text-align: left;
 }
@@ -38,7 +38,7 @@
 }
 
 .task-modal {
-  background: var(--bg);
+  background: var(--surface-base);
   border-radius: var(--radius-modal) var(--radius-modal) 0 0;
   padding: var(--space-3) var(--space-3) var(--space-4);
   width: 100%;
@@ -71,8 +71,8 @@
   border-radius: var(--radius-input);
   font-size: var(--font-primary-size);
   line-height: var(--font-primary-line);
-  background: var(--bg);
-  color: var(--text-h);
+  background: var(--surface-base);
+  color: var(--text-primary);
 }
 
 .task-modal__name-input:focus {
@@ -99,7 +99,7 @@
 
 .task-modal__close:hover {
   background: var(--border-default);
-  color: var(--text-h);
+  color: var(--text-primary);
 }
 
 .task-modal__segments {
@@ -168,7 +168,7 @@
   font-size: var(--font-chip-mobile-size);
   line-height: var(--font-chip-mobile-line);
   font-weight: 500;
-  color: var(--text-h);
+  color: var(--text-primary);
   cursor: pointer;
   gap: var(--space-1);
 }
@@ -210,7 +210,7 @@
 }
 
 .segment-picker {
-  background: var(--bg);
+  background: var(--surface-base);
   border-radius: var(--radius-modal) var(--radius-modal) 0 0;
   padding: var(--space-3) var(--space-3) var(--space-4);
   width: 100%;
@@ -280,7 +280,7 @@
   padding: var(--space-1) var(--space-2);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-input);
-  background: var(--bg);
+  background: var(--surface-base);
   font-size: var(--font-chip-mobile-size);
   line-height: var(--font-chip-mobile-line);
   color: var(--text-secondary);
@@ -380,7 +380,7 @@
   padding: 0 var(--space-2);
   border-radius: var(--radius-input);
   border: 1px solid var(--border-strong);
-  background: var(--bg);
+  background: var(--surface-base);
   font-size: var(--font-primary-size);
   line-height: var(--font-primary-line);
   cursor: pointer;

--- a/src/styles/ui-guide.css
+++ b/src/styles/ui-guide.css
@@ -29,10 +29,16 @@
 
 .ui-guide-toc__link {
   font-size: var(--font-chip-mobile-size);
+  line-height: var(--font-chip-mobile-line);
   color: var(--color-link);
   text-decoration: none;
   font-weight: 500;
   white-space: nowrap;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
 }
 
 .ui-guide-toc__link:hover {
@@ -80,7 +86,7 @@
 
 .ui-guide-section h2 {
   font-size: var(--font-title-sm-size);
-  color: var(--text-h);
+  color: var(--text-primary);
   margin-bottom: var(--space-2);
 }
 
@@ -108,7 +114,7 @@
 }
 
 .type-specimen__demo {
-  color: var(--text-h);
+  color: var(--text-primary);
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -150,7 +156,7 @@
   border: 1px solid var(--border-default);
   border-radius: var(--radius-card);
   overflow: hidden;
-  background: var(--bg);
+  background: var(--surface-base);
 }
 
 .token-card__preview {
@@ -169,7 +175,7 @@
 .token-card__preview-box {
   width: 60px;
   height: 60px;
-  background: var(--bg);
+  background: var(--surface-base);
   border: 1px solid var(--border-default);
 }
 
@@ -182,7 +188,7 @@
 
 .token-card__name {
   font-family: var(--mono);
-  font-size: 0.8rem;
+  font-size: var(--font-chip-mobile-size);
   font-weight: 600;
   color: var(--priority-medium);
   background: var(--surface-filter-active);
@@ -196,4 +202,13 @@
   color: var(--text-secondary);
   line-height: 1.4;
   margin: 0;
+}
+.ui-guide-subheading {
+  font-size: var(--font-chip-mobile-size);
+  line-height: var(--font-chip-mobile-line);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  margin: var(--space-3) 0 var(--space-2);
 }


### PR DESCRIPTION
## Changes
- Added additional content to UI Guide.
- Pass to clean up any lingering hard-coded styling.

## UI Implementation Guide (`/#/ui-guide`)

Living style guide accessible at `/#/ui-guide`. Implemented as a hidden route
(not linked from the main app) for developer and portfolio reference.

**14 sections covering the full token system:**
Typography · Spacing · Radius · Surfaces · Borders · Text · Icons ·
Cognitive Load · Priority · Context Colors · Actions · System States ·
Feature Tokens · Elevation

**Feature Tokens section** documents state-specific token groups (Snoozed Tasks,
Active Filters, Keystone) — demonstrating that feature states are first-class
design system citizens, not one-off hardcoded values.

**Technical:** TOC renders as accessible `<button>` elements with smooth scroll;
button reset styles moved from JSX inline to CSS; sticky sidebar on desktop,
horizontal scroll on mobile; helper components (`ColorToken`, `TypeToken`,
`SpaceToken`, `RadiusToken`, `ShadowToken`) are reusable for future additions.