### PR TITLE
remove explicit .ts extension from useFocusTrap import

### DIFF
--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { useFocusTrap } from "../hooks/useFocusTrap.ts";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 import "../styles/task-form.css";
 import {
   LOAD_PILL_COLORS, PRIORITY_PILL_COLORS, getContextColor,


### PR DESCRIPTION
`TaskForm.tsx` imports with an explicit extension:
```tsx
import { useFocusTrap } from "../hooks/useFocusTrap.ts";
```

Vite resolves extensions automatically. The `.ts` should be omitted for
consistency with every other import in the codebase.